### PR TITLE
Fix utility functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,13 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.5</version>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/mitre/cpe/common/Utilities.java
+++ b/src/main/java/org/mitre/cpe/common/Utilities.java
@@ -105,16 +105,19 @@ public class Utilities {
     }
 
     /**
-     * Searches string for special characters * and ?
-     * @param string String to be searched
-     * @return true if string contains wildcard, false otherwise
+     * Searches string for unquoted special characters * and ?
+     *
+     * @param str String to be searched
+     * @return true if string contains any unquoted special characters, otherwise false
      */
-    public static boolean containsWildcards(String string) {
-        if (string.contains("*") || string.contains("?")) {
-            if (!(string.contains("\\"))) {
-                return true;
+    public static boolean containsWildcards(String str) {
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (c == '*' || c == '?') {
+                if (i == 0 || str.charAt(i - 1) != '\\') {
+                    return true;
+                }
             }
-            return false;
         }
         return false;
     }
@@ -125,11 +128,7 @@ public class Utilities {
      * @return true if number is even, false if not
      */
     public static boolean isEvenNumber(int num) {
-        if (num % 2 == 0) {
-            return true;
-        } else {
-            return false;
-        }
+        return num % 2 == 0 ? true : false;
     }
 
     /**
@@ -145,10 +144,11 @@ public class Utilities {
         boolean active = false;
         int i = 0;
         while (i < end) {
+            active = !active && str.charAt(i) == '\\';
             if (active && (i >= start)) {
-                result = result + 1;
+                result += 1;
             }
-            i = i + 1;
+            i += 1;
         }
         return result;
     }
@@ -248,9 +248,9 @@ public class Utilities {
             if (in.charAt(i) == ':') {
                 if (in.charAt(i - 1) != '\\') {
                     count++;
-                }
-                if ((i + 1) < in.length() && in.charAt(i + 1) == ':') {
-                    throw new ParseException("Error parsing formatted string.  Found empty component", 0);
+                    if (((i + 1) < in.length() && in.charAt(i + 1) == ':') || ((i + 1) == in.length())) {
+                        throw new ParseException("Error parsing formatted string.  Found empty component", 0);
+                    }
                 }
             }
         }

--- a/src/test/java/org/mitre/cpe/common/UtilitiesTest.java
+++ b/src/test/java/org/mitre/cpe/common/UtilitiesTest.java
@@ -1,0 +1,100 @@
+package org.mitre.cpe.common;
+
+import static org.junit.Assert.assertEquals;
+
+import java.text.ParseException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class UtilitiesTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    @Parameters({"cpe:2.3:a:adobe:*:9.*:*:PalmOS:*:*:*:*:*",
+        "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win2003:x64:*",
+        "cpe:2.3:a:adobe:*:9.*:*:PalmOS:with\\:quoted:\\::colons:*:*",
+        "cpe:2.3:a:adobe:*:9.*:*:with:quoted:colon:at:the:end\\:"})
+    public void testValidateFsHappyCase(String fs) throws ParseException {
+        Utilities.validateFS(fs);
+    }
+
+    @Test
+    @Parameters({"cpe:2.3:a:*:*:*:*:empty:element:at:the:end:",
+        "cpe:2.3:a:adobe:*:9.*:empty:element:in:the:middle::*",
+        "wrong:start:a:adobe:*:9.*:*:PalmOS:*:*:*:*:*",
+        "cpe:2.3:a:adobe:*:9.*:*:*:*:13:elements:*:*:*",
+        "cpe:2.3:a:adobe:*:9.*:*:more:than:13:elements:*:*:*:*:*",
+        "cpe:2.3:a:adobe:*:9.*:*:*:*:11:elements:*",
+        "cpe:2.3:a:adobe:*:less:than:11:elements:*"})
+    public void testValidateFsInvalid(String fs) throws ParseException {
+        exception.expect(ParseException.class);
+        Utilities.validateFS(fs);
+    }
+
+    @Test
+    @Parameters({"asdf, 0, 4, 0",
+        "as\\df, 0, 5, 1",
+        "as\\\\df, 0, 6, 1",
+        "as\\\\\\df, 0, 7, 2",
+        "\\.\\?\\&asdf, 0, 10, 3",
+        "\\.\\?\\&asdf, 2, 10, 2",
+        "\\.\\?\\&asdf, 3, 10, 1",
+        "\\.\\?\\&asdf, 0, 1, 1",
+        "\\.\\?\\&asdf, 2, 5, 2",
+        "\\.\\?\\&asdf, 0, 0, 0",
+        "as\\df, -4, 5, 1",
+    })
+    public void testCountEscapeCharactersHappyCase(String str, int start, int end, int expected) {
+        assertEquals(expected, Utilities.countEscapeCharacters(str, start, end));
+    }
+
+    @Test
+    public void testCountEscapeCharactersEndOutOfBounds() {
+        exception.expect(IndexOutOfBoundsException.class);
+        Utilities.countEscapeCharacters("as\\df", 0, 15);
+    }
+
+    @Test
+    public void testValidateURIHappyCase() throws ParseException {
+        Utilities.validateURI("cpe:/a:hp:insight_diagnostics:7.4.0.1570::~~online~win2003~x64~");
+    }
+
+    @Test
+    @Parameters({"cpe:2.3:/a:wrong:start",
+        "cpe:/a:hp:insight_diagnostics:7.4.0.1570::~~online~win2003~x64~::wrong_number_elements"
+    })
+    public void testValidateURIInvalid(String uri) throws ParseException {
+        exception.expect(ParseException.class);
+        Utilities.validateURI(uri);
+    }
+
+    @Test
+    @Parameters({"0, true",
+        "1, false",
+        "8, true",
+        "-7, false",
+        "-16, true"})
+    public void testIsEvenNumber(int input, boolean expected) {
+        assertEquals(expected, Utilities.isEvenNumber(input));
+    }
+
+    @Test
+    @Parameters({"foo, false",
+        "foo\\?, false",
+        "foo?, true",
+        "\\*bar, false",
+        "*bar, true",
+        "\\*foo?, true"})
+    public void testContainsWildcards(String input, boolean expected) {
+        assertEquals(expected, Utilities.containsWildcards(input));
+    }
+}


### PR DESCRIPTION
This pull request fixes some of the utility functions:
- **validateFS** -> when detecting empty elements skip quoted colons and detect empty element at the end of the string
- **containsWildcards** and **countEscapeCharacters** -> fixed as it defined in the [official pseudocode](https://www.govinfo.gov/content/pkg/GOVPUB-C13-51b0b55a28ff213c79c6d015d61addd3/pdf/GOVPUB-C13-51b0b55a28ff213c79c6d015d61addd3.pdf)

Also added some tests for the utility functions